### PR TITLE
Fixing deprecated `inner1d` using `np.dot` (for python3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 # Do not version intermediary documentation files.
 doc/build/
+build/
+linear_model.egg-info/
 
 # Ignore ipython notebook temp files.
 example/.ipynb_checkpoints

--- a/linear_model.py
+++ b/linear_model.py
@@ -31,7 +31,7 @@
 import numpy as np
 import scipy.stats
 from scipy.special import gammaln
-from numpy.core.umath_tests import inner1d
+#from numpy.core.umath_tests import inner1d
 
 # --------------------------------------------------------------------------- #
 #                              Module Functions
@@ -938,7 +938,7 @@ class BayesianLinearModel(object):
         # Create N random samples (1xD) drawn from multiple, random and unique
         # multivariate normal distributions.
         L = np.rollaxis(np.linalg.cholesky(sigma.T).T, 0, 2)
-        sigma = inner1d(np.rollaxis(rn, 0, 2).T, L.T)
+        sigma = np.dot(np.rollaxis(rn, 0, 2).T, L.T)
 
         # Return (NxD) samples drawn from multivariate-normal, inverse-gamma
         # distribution.

--- a/linear_model.py
+++ b/linear_model.py
@@ -297,7 +297,7 @@ def _negative_log_marginal_likelihood(params, basis, X, y):
         S_hat = _predict_variance(phi, np.linalg.inv(S), alpha, beta)
         nlml = -np.sum(_posterior_likelihood(y, m_hat, S_hat, alpha))
     except:
-        print params
+        print(params)
         raise
 
     return nlml

--- a/makefile
+++ b/makefile
@@ -1,0 +1,2 @@
+install:
+	pip install .


### PR DESCRIPTION
Hi @asherbender , 

While I have implemented my own Bayesian linear regression, I found your solution to be neater, so I generally use it.

You may be interested to know that the `inner1d` function has already been deprecated. In this PR I simply replace the functionality of `inner1d` by `np.dot()`. 

This version was tested in `Python 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0] on linux`

Kind regards

